### PR TITLE
Single Agg results dont display the bucket name as key

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,16 +41,14 @@ function tabify(response, options) {
 function collectBucket(node, stack=[]) {
     if (!node)
         return;
-
+    
     const keys = Object.keys(node);
-
+    
     // Use old school `for` so we can break control flow by returning.
     for(let i = 0; i < keys.length; i++) {
         const key = keys[i];
         const value = node[key];
-
         if (typeof value === 'object' && value !== null) {
-
             if ("hits" in value && Array.isArray(value.hits) && value.hits.length === 1) {
                 if ("sort" in value.hits[0]) {
                     value.hits[0]._source['sort'] = value.hits[0].sort[0];
@@ -67,7 +65,13 @@ function collectBucket(node, stack=[]) {
             {
                 return extractBuckets(value, [...stack, key]);
             }
+
             return collectBucket(value, [...stack, key]);
+        }
+
+        if (key === "value" && typeof value !== "object" && stack.length === 1) {
+            let collectedObject = collectBucket({[stack[0]]: value});
+            node = collectedObject;
         }
     }
 
@@ -110,9 +114,9 @@ function extractTree(buckets, stack) {
             if(key === "key"){
                 key = stack[stack.length - 2]
             }
-
+            
             tree[key] = value;
-
+        
             return tree;
         }, {});
     });


### PR DESCRIPTION
For single aggregation responses, we get `value` as our `key`, despite the name of the bucket/aggregation.  

Example data/response...

```
{
    "hits": {
        "hits": [],
        "total": 19,
        "max_score": 0.0
    },
    "_shards": {
        "successful": 10,
        "failed": 0,
        "total": 10
    },
    "took": 10,
    "aggregations": {
        "queue_size": {
            "value": 138.0
        }
    },
    "timed_out": false
}
```

In es-tabify's current state, tabify would generate...

```
[
  {
    "value": 138
  }
]
```

But we actually expect to get ... 

```
[
  {
    "queue_size": 138
  }
]
```

This PR fixes this issue.  I have tested it against other, nested/multi aggregations responses as well and all seems good.  